### PR TITLE
Print metrics using bash array syntax

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,17 +53,18 @@ struct MFileIdx {
 }
 
 fn read_metric<T: Read>(buffer: &mut T) -> Result<String, std::io::Error> {
-    let mut metric = String::new();
+    let mut metric = "(".to_string();
     while let Ok(size) = buffer.by_ref().read_u8() {
         let mut section = buffer.by_ref().take(size as u64);
         let mut part = String::new();
         try!(section.read_to_string(&mut part));
         part = part.replace("\\", "\\\\").replace("'", "\\'");
-        if metric.len() != 0 {
-            metric += ".";
+        if metric.len() != 1 {
+            metric += " ";
         }
         metric = metric + "'" + &part + "'";
     }
+    metric += ")";
     return Ok(metric);
 }
 


### PR DESCRIPTION
After working with this script a bit I come to conclusion it would be better to pring metrics in a format that can be easily converted to bash array. It makes it so much easier to integrate with bash scripts and other tooling.

For example one can do

```
./target/debug/mstore-info -l 1487808000.idx | while read line
do
    declare -a metric="${line}"
    ...
done
```

This allows convenient access to inidividual tooling, or can be passed as multi argument metric to dbb-admin:

```ddb-admin bitmap show <time> <mucket> "${metric[@]}"```

All escaping is handled by bash